### PR TITLE
Add a virtual destructor for ColourProvider

### DIFF
--- a/include/pangolin/gl/colour.h
+++ b/include/pangolin/gl/colour.h
@@ -148,6 +148,9 @@ public:
 
     /// Reset colours
     virtual void Reset() = 0;
+
+    /// Virtual destructor to ensure correct destruction of derived classes
+    virtual ~ColourProvider() = default;
 };
 
 /// A ColourWheel is like a continuous colour palate that can be sampled.


### PR DESCRIPTION
This fixes a compiler warning and ensures that all classes that derive form ColourProvider are destructed properly.