### PR TITLE
Keep ColorWheel interface and add extra method to implement ColorProvider interface.

### DIFF
--- a/include/pangolin/gl/colour.h
+++ b/include/pangolin/gl/colour.h
@@ -173,9 +173,15 @@ public:
     }
 
     /// Return next unique colour from ColourWheel.
-    inline Colour GetNext() override
+    inline Colour GetUniqueColour()
     {
         return GetColourBin(unique_colours++);
+    }
+
+    /// Return next unique colour from ColourWheel for ColorProvider.
+    inline Colour GetNext() override
+    {
+        return GetUniqueColour();
     }
 
     /// Reset colour wheel counter to initial state


### PR DESCRIPTION
This implements the ColorProvider interface without breaking old code that uses ColorWheel::GetUniqueColour() method.