### PR TITLE
Keep Plotter::ResetColourWheel() for API compatiblilty

### DIFF
--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -192,8 +192,14 @@ public:
     void ClearImplicitPlots();
     void AddImplicitPlot();
 
-    /// Reset colour wheel to initial state. May be useful together with ClearSeries() / ClearMarkers()
+    /// Reset colour provider to initial state. May be useful together with ClearSeries() / ClearMarkers()
     void ResetColourProvider();
+
+    /// Alias for ResetColourProvider for API compatibility.
+    void ResetColourWheel()
+    {
+        ResetColourProvider();
+    }
 
     void ShowHoverLines(bool show)
     {


### PR DESCRIPTION
This PR keeps the API compatibility for the Plotter for a normal user. For usecases where Plotter is subclassed the missing member colour_wheel might still break something.