### PR TITLE
Keep plotter interface

### DIFF
--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -135,11 +135,26 @@ struct Colour
 
 };
 
+/// The base class of colour providers. It does not enforce any strategy on how to provide the colours
+class ColourProvider
+{
+public:
+    /// Adds a colour to this provider. Some providers that generate colours
+    /// might not need to implement this (e.g. ColourWheel)
+    virtual void Add(const Colour& colour) {};
+
+    /// Get next colour. In the case of generation it would create a new one.
+    virtual Colour GetNext() = 0;
+
+    /// Reset colours
+    virtual void Reset() = 0;
+};
+
 /// A ColourWheel is like a continuous colour palate that can be sampled.
 /// In the future, different ColourWheels will be supported, but this one
 /// is based on sampling hues in HSV colourspace. An indefinite number of
 /// unique colours are sampled using the golden angle.
-class ColourWheel
+class ColourWheel : public ColourProvider
 {
 public:
     /// Construct ColourWheel with Saturation, Value and Alpha constant.
@@ -158,13 +173,13 @@ public:
     }
 
     /// Return next unique colour from ColourWheel.
-    inline Colour GetUniqueColour()
+    inline Colour GetNext() override
     {
         return GetColourBin(unique_colours++);
     }
 
     /// Reset colour wheel counter to initial state
-    inline void Reset() {
+    inline void Reset() override {
       unique_colours = 0;
     }
 
@@ -173,6 +188,34 @@ protected:
     float sat;
     float val;
     float alpha;
+};
+
+/// A simple Circular Buffer of colours
+class ColourCircularBuffer : public ColourProvider
+{
+public:
+    /// Adds a new color to the vector
+    virtual void Add(const Colour& colour) override {
+        colours.emplace_back(colour);
+        current_idx = colours.size() - 1;
+    }
+
+    /// Return next colour in the buffer
+    inline Colour GetNext() override
+    {
+        current_idx = (current_idx + 1) % colours.size();
+        return colours[current_idx];
+    }
+
+    /// Clear all added colours
+    inline void Reset() override {
+        colours.clear();
+        current_idx = 0;
+    }
+
+protected:
+    std::vector<Colour> colours;
+    size_t current_idx = 0;
 };
 
 }

--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -148,6 +148,9 @@ public:
 
     /// Reset colours
     virtual void Reset() = 0;
+
+    /// Virtual destructor to ensure correct destruction of derived classes
+    virtual ~ColourProvider() = default;
 };
 
 /// A ColourWheel is like a continuous colour palate that can be sampled.

--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -176,9 +176,15 @@ public:
     }
 
     /// Return next unique colour from ColourWheel.
-    inline Colour GetNext() override
+    inline Colour GetUniqueColour()
     {
         return GetColourBin(unique_colours++);
+    }
+
+    /// Return next unique colour from ColourWheel for ColorProvider.
+    inline Colour GetNext() override
+    {
+        return GetUniqueColour();
     }
 
     /// Reset colour wheel counter to initial state

--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -141,7 +141,7 @@ class ColourProvider
 public:
     /// Adds a colour to this provider. Some providers that generate colours
     /// might not need to implement this (e.g. ColourWheel)
-    virtual void Add(const Colour& colour) {};
+    virtual void Add(const Colour& /*colour*/) {};
 
     /// Get next colour. In the case of generation it would create a new one.
     virtual Colour GetNext() = 0;

--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -29,6 +29,7 @@
 
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 
 namespace pangolin
@@ -139,9 +140,8 @@ struct Colour
 class ColourProvider
 {
 public:
-    /// Adds a colour to this provider. Some providers that generate colours
-    /// might not need to implement this (e.g. ColourWheel)
-    virtual void Add(const Colour& /*colour*/) {};
+    /// Get colour for a given index.
+    virtual Colour GetColourBin(int i) const = 0;
 
     /// Get next colour. In the case of generation it would create a new one.
     virtual Colour GetNext() = 0;
@@ -154,21 +154,19 @@ public:
 };
 
 /// A ColourWheel is like a continuous colour palate that can be sampled.
-/// In the future, different ColourWheels will be supported, but this one
-/// is based on sampling hues in HSV colourspace. An indefinite number of
-/// unique colours are sampled using the golden angle.
-class ColourWheel : public ColourProvider
+/// This one is based on sampling hues in HSV colourspace. An indefinite
+/// number of unique colours are sampled using the golden angle.
+class HSVColourWheel : public ColourProvider
 {
 public:
     /// Construct ColourWheel with Saturation, Value and Alpha constant.
-    inline ColourWheel(float saturation = 0.5f, float value = 1.0f, float alpha = 1.0f)
+    inline HSVColourWheel(float saturation = 0.5f, float value = 1.0f, float alpha = 1.0f)
         : unique_colours(0), sat(saturation), val(value), alpha(alpha)
     {
-
     }
 
     /// Use Golden ratio (/angle) to pick well spaced colours.
-    inline Colour GetColourBin(int i) const
+    inline Colour GetColourBin(int i) const override
     {
         float hue = i * 0.5f * (3.0f - sqrt(5.0f));
         hue -= (int)hue;
@@ -176,20 +174,15 @@ public:
     }
 
     /// Return next unique colour from ColourWheel.
-    inline Colour GetUniqueColour()
+    inline Colour GetNext() override
     {
         return GetColourBin(unique_colours++);
     }
 
-    /// Return next unique colour from ColourWheel for ColorProvider.
-    inline Colour GetNext() override
-    {
-        return GetUniqueColour();
-    }
-
     /// Reset colour wheel counter to initial state
-    inline void Reset() override {
-      unique_colours = 0;
+    inline void Reset() override
+    {
+        unique_colours = 0;
     }
 
 protected:
@@ -199,14 +192,60 @@ protected:
     float alpha;
 };
 
+
+/// A ColourWheel is like a continuous colour palate that can be sampled.
+class ColourWheel
+{
+public:
+    /// Construct ColourWheel using HSVColourWheel with Saturation, Value and Alpha constant.
+    inline ColourWheel(float saturation = 0.5f, float value = 1.0f, float alpha = 1.0f)
+        : colour_provider(std::make_unique<HSVColourWheel>(saturation,value, alpha))
+    {
+    }
+
+    /// Construct ColourWheel with a given colour provider.
+    inline ColourWheel(std::unique_ptr<ColourProvider>&& colour_provider)
+        : colour_provider(std::move(colour_provider))
+    {
+    }
+
+    /// Use Golden ratio (/angle) to pick well spaced colours.
+    inline Colour GetColourBin(int i) const
+    {
+        return colour_provider->GetColourBin(i);
+    }
+
+    /// Return next unique colour from ColourWheel.
+    inline Colour GetUniqueColour()
+    {
+        return colour_provider->GetNext();
+    }
+
+    /// Reset colour wheel counter to initial state
+    inline void Reset() {
+      colour_provider->Reset();
+    }
+
+protected:
+    std::unique_ptr<ColourProvider> colour_provider;
+};
+
+
 /// A simple Circular Buffer of colours
 class ColourCircularBuffer : public ColourProvider
 {
 public:
     /// Adds a new color to the vector
-    virtual void Add(const Colour& colour) override {
+    void Add(const Colour& colour) {
         colours.emplace_back(colour);
         current_idx = colours.size() - 1;
+    }
+
+    /// Return colour for index
+    inline Colour GetColourBin(int i) const override
+    {
+        i = std::clamp(i, 0, static_cast<int>(colours.size())-1);
+        return colours[i];
     }
 
     /// Return next colour in the buffer

--- a/components/pango_opengl/include/pangolin/gl/colour.h
+++ b/components/pango_opengl/include/pangolin/gl/colour.h
@@ -27,10 +27,12 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <vector>
 
 namespace pangolin
 {
@@ -193,6 +195,42 @@ protected:
 };
 
 
+/// A simple Circular Buffer of colours
+class ColourCircularBuffer : public ColourProvider
+{
+public:
+    /// Adds a new color to the vector
+    void Add(const Colour& colour) {
+        colours.emplace_back(colour);
+        current_idx = colours.size() - 1;
+    }
+
+    /// Return colour for index
+    inline Colour GetColourBin(int i) const override
+    {
+        i = std::clamp(i, 0, static_cast<int>(colours.size()) - 1);
+        return colours[i];
+    }
+
+    /// Return next colour in the buffer
+    inline Colour GetNext() override
+    {
+        current_idx = (current_idx + 1) % colours.size();
+        return colours[current_idx];
+    }
+
+    /// Clear all added colours
+    inline void Reset() override {
+        colours.clear();
+        current_idx = 0;
+    }
+
+protected:
+    std::vector<Colour> colours;
+    size_t current_idx = 0;
+};
+
+
 /// A ColourWheel is like a continuous colour palate that can be sampled.
 class ColourWheel
 {
@@ -228,42 +266,6 @@ public:
 
 protected:
     std::unique_ptr<ColourProvider> colour_provider;
-};
-
-
-/// A simple Circular Buffer of colours
-class ColourCircularBuffer : public ColourProvider
-{
-public:
-    /// Adds a new color to the vector
-    void Add(const Colour& colour) {
-        colours.emplace_back(colour);
-        current_idx = colours.size() - 1;
-    }
-
-    /// Return colour for index
-    inline Colour GetColourBin(int i) const override
-    {
-        i = std::clamp(i, 0, static_cast<int>(colours.size())-1);
-        return colours[i];
-    }
-
-    /// Return next colour in the buffer
-    inline Colour GetNext() override
-    {
-        current_idx = (current_idx + 1) % colours.size();
-        return colours[current_idx];
-    }
-
-    /// Clear all added colours
-    inline void Reset() override {
-        colours.clear();
-        current_idx = 0;
-    }
-
-protected:
-    std::vector<Colour> colours;
-    size_t current_idx = 0;
 };
 
 }

--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -192,8 +192,14 @@ public:
     void ClearImplicitPlots();
     void AddImplicitPlot();
 
-    /// Reset colour wheel to initial state. May be useful together with ClearSeries() / ClearMarkers()
+    /// Reset colour provider to initial state. May be useful together with ClearSeries() / ClearMarkers()
     void ResetColourProvider();
+
+    /// Alias for ResetColourProvider for API compatibility.
+    void ResetColourWheel()
+    {
+        ResetColourProvider();
+    }
 
     void ShowHoverLines(bool show)
     {

--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -101,6 +101,17 @@ struct Marker
 class PANGOLIN_EXPORT Plotter : public View, Handler
 {
 public:
+
+    /// Constructor without a colour provider. Defaults to a color wheel
+    Plotter(
+        DataLog* default_log,
+        float left = 0, float right = 600, float bottom = -1, float top = 1,
+        float tickx = 30, float ticky = 0.5,
+        Plotter* linked_plotter_x = 0,
+        Plotter* linked_plotter_y = 0
+    );
+
+    /// Constructor that allows the passing of a colour provider
     Plotter(
         DataLog* default_log,
         std::unique_ptr<ColourProvider>&& colour_prov,

--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -103,6 +103,7 @@ class PANGOLIN_EXPORT Plotter : public View, Handler
 public:
     Plotter(
         DataLog* default_log,
+        std::unique_ptr<ColourProvider>&& colour_prov,
         float left=0, float right=600, float bottom=-1, float top=1,
         float tickx=30, float ticky=0.5,
         Plotter* linked_plotter_x = 0,
@@ -181,7 +182,7 @@ public:
     void AddImplicitPlot();
 
     /// Reset colour wheel to initial state. May be useful together with ClearSeries() / ClearMarkers()
-    void ResetColourWheel();
+    void ResetColourProvider();
 
     void ShowHoverLines(bool show)
     {
@@ -249,7 +250,7 @@ protected:
 
     DataLog* default_log;
 
-    ColourWheel colour_wheel;
+    std::unique_ptr<ColourProvider> colour_provider;
     Colour colour_bg;
     Colour colour_tk;
     Colour colour_ax;

--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -102,7 +102,7 @@ class PANGOLIN_EXPORT Plotter : public View, Handler
 {
 public:
 
-    /// Constructor without a colour provider. Defaults to a color wheel
+    /// Constructor without a colour provider. Defaults to a HSV color wheel
     Plotter(
         DataLog* default_log,
         float left = 0, float right = 600, float bottom = -1, float top = 1,

--- a/components/pango_plot/include/pangolin/plot/plotter.h
+++ b/components/pango_plot/include/pangolin/plot/plotter.h
@@ -114,7 +114,7 @@ public:
     /// Constructor that allows the passing of a colour provider
     Plotter(
         DataLog* default_log,
-        std::unique_ptr<ColourProvider>&& colour_prov,
+        ColourWheel&& colour_wheel,
         float left=0, float right=600, float bottom=-1, float top=1,
         float tickx=30, float ticky=0.5,
         Plotter* linked_plotter_x = 0,
@@ -192,14 +192,8 @@ public:
     void ClearImplicitPlots();
     void AddImplicitPlot();
 
-    /// Reset colour provider to initial state. May be useful together with ClearSeries() / ClearMarkers()
-    void ResetColourProvider();
-
-    /// Alias for ResetColourProvider for API compatibility.
-    void ResetColourWheel()
-    {
-        ResetColourProvider();
-    }
+    /// Reset colour wheel to initial state. May be useful together with ClearSeries() / ClearMarkers()
+    void ResetColourWheel();
 
     void ShowHoverLines(bool show)
     {
@@ -267,7 +261,7 @@ protected:
 
     DataLog* default_log;
 
-    std::unique_ptr<ColourProvider> colour_provider;
+    ColourWheel colour_wheel;
     Colour colour_bg;
     Colour colour_tk;
     Colour colour_ax;

--- a/components/pango_plot/src/plotter.cpp
+++ b/components/pango_plot/src/plotter.cpp
@@ -198,6 +198,20 @@ void Plotter::PlotImplicit::CreateDistancePlot(const std::string& /*dist*/)
 
 Plotter::Plotter(
     DataLog* log,
+    float left, float right, float bottom, float top,
+    float tickx, float ticky,
+    Plotter* linked_plotter_x,
+    Plotter* linked_plotter_y
+)   : Plotter(log,
+      std::make_unique<pangolin::ColourWheel>(0.6),
+      left,right,bottom,top,
+      tickx, ticky,
+      linked_plotter_x, linked_plotter_y)
+{
+}
+
+Plotter::Plotter(
+    DataLog* log,
     std::unique_ptr<ColourProvider>&& colour_prov,
     float left, float right, float bottom, float top,
     float tickx, float ticky,

--- a/components/pango_plot/src/plotter.cpp
+++ b/components/pango_plot/src/plotter.cpp
@@ -198,12 +198,13 @@ void Plotter::PlotImplicit::CreateDistancePlot(const std::string& /*dist*/)
 
 Plotter::Plotter(
     DataLog* log,
+    std::unique_ptr<ColourProvider>&& colour_prov,
     float left, float right, float bottom, float top,
     float tickx, float ticky,
     Plotter* linked_plotter_x,
     Plotter* linked_plotter_y
 )   : default_log(log),
-      colour_wheel(0.6f),
+      colour_provider(std::move(colour_prov)),
       rview_default(left,right,bottom,top), rview(rview_default), target(rview),
       selection(0,0,0,0),
       track(false), track_x("$i"), track_y(""),
@@ -1113,7 +1114,7 @@ void Plotter::AddSeries(const std::string& x_expr, const std::string& y_expr,
     const std::string& title, DataLog *log)
 {
     if( !std::isfinite(colour.r) ) {
-        colour = colour_wheel.GetUniqueColour();
+        colour = colour_provider->GetNext();
     }
     plotseries.push_back( PlotSeries() );
     plotseries.back().CreatePlot(x_expr, y_expr, colour, (title == "$y") ? PlotTitleFromExpr(y_expr) : title);
@@ -1166,9 +1167,9 @@ void Plotter::ClearMarkers()
     plotmarkers.clear();
 }
 
-void Plotter::ResetColourWheel()
+void Plotter::ResetColourProvider()
 {
-    colour_wheel.Reset();
+    colour_provider->Reset();
 }
 
 }

--- a/components/pango_plot/src/plotter.cpp
+++ b/components/pango_plot/src/plotter.cpp
@@ -203,7 +203,7 @@ Plotter::Plotter(
     Plotter* linked_plotter_x,
     Plotter* linked_plotter_y
 )   : Plotter(log,
-      std::make_unique<pangolin::ColourWheel>(0.6),
+      ColourWheel(0.6),
       left,right,bottom,top,
       tickx, ticky,
       linked_plotter_x, linked_plotter_y)
@@ -212,13 +212,13 @@ Plotter::Plotter(
 
 Plotter::Plotter(
     DataLog* log,
-    std::unique_ptr<ColourProvider>&& colour_prov,
+    ColourWheel&& colour_wheel,
     float left, float right, float bottom, float top,
     float tickx, float ticky,
     Plotter* linked_plotter_x,
     Plotter* linked_plotter_y
 )   : default_log(log),
-      colour_provider(std::move(colour_prov)),
+      colour_wheel(std::move(colour_wheel)),
       rview_default(left,right,bottom,top), rview(rview_default), target(rview),
       selection(0,0,0,0),
       track(false), track_x("$i"), track_y(""),
@@ -1128,7 +1128,7 @@ void Plotter::AddSeries(const std::string& x_expr, const std::string& y_expr,
     const std::string& title, DataLog *log)
 {
     if( !std::isfinite(colour.r) ) {
-        colour = colour_provider->GetNext();
+        colour = colour_wheel.GetUniqueColour();
     }
     plotseries.push_back( PlotSeries() );
     plotseries.back().CreatePlot(x_expr, y_expr, colour, (title == "$y") ? PlotTitleFromExpr(y_expr) : title);
@@ -1181,9 +1181,9 @@ void Plotter::ClearMarkers()
     plotmarkers.clear();
 }
 
-void Plotter::ResetColourProvider()
+void Plotter::ResetColourWheel()
 {
-    colour_provider->Reset();
+    colour_wheel.Reset();
 }
 
 }

--- a/examples/SimplePlot/main.cpp
+++ b/examples/SimplePlot/main.cpp
@@ -18,8 +18,21 @@ int main(/*int argc, char* argv[]*/)
 
   const float tinc = 0.01f;
 
+  std::unique_ptr<pangolin::ColourProvider> colours;
+  bool use_wheel = true; /// By default we use a ColourWheel provider
+
+  if (use_wheel) {
+      colours = std::make_unique<pangolin::ColourWheel>(0.6);
+  }
+  else {
+      colours = std::make_unique<pangolin::ColourCircularBuffer>();
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.3f));
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.6f));
+      colours->Add(pangolin::Colour::Green().WithAlpha(0.9f));
+  }
+
   // OpenGL 'view' of data. We might have many views of the same data.
-  pangolin::Plotter plotter(&log,0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
+  pangolin::Plotter plotter(&log, std::move(colours), 0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
   plotter.SetBounds(0.0, 1.0, 0.0, 1.0);
   plotter.Track("$i");
 

--- a/examples/SimplePlot/main.cpp
+++ b/examples/SimplePlot/main.cpp
@@ -18,11 +18,11 @@ int main(/*int argc, char* argv[]*/)
 
   const float tinc = 0.01f;
 
-  const bool use_wheel = true; /// By default we use a ColourWheel provider
+  const bool use_hsv_wheel = true; /// By default we use a HSV ColourWheel provider
 
   // OpenGL 'view' of data. We might have many views of the same data.
   pangolin::Plotter plotter = [&](){
-    if (use_wheel) {
+    if (use_hsv_wheel) {
       return pangolin::Plotter(&log, 0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
     }
     else {

--- a/examples/SimplePlot/main.cpp
+++ b/examples/SimplePlot/main.cpp
@@ -18,21 +18,21 @@ int main(/*int argc, char* argv[]*/)
 
   const float tinc = 0.01f;
 
-  std::unique_ptr<pangolin::ColourProvider> colours;
-  bool use_wheel = true; /// By default we use a ColourWheel provider
+  const bool use_wheel = true; /// By default we use a ColourWheel provider
 
-  if (use_wheel) {
-      colours = std::make_unique<pangolin::ColourWheel>(0.6);
-  }
-  else {
-      colours = std::make_unique<pangolin::ColourCircularBuffer>();
+  // OpenGL 'view' of data. We might have many views of the same data.
+  pangolin::Plotter plotter = [&](){
+    if (use_wheel) {
+      return pangolin::Plotter(&log, 0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
+    }
+    else {
+      auto colours = std::make_unique<pangolin::ColourCircularBuffer>();
       colours->Add(pangolin::Colour::Green().WithAlpha(0.3f));
       colours->Add(pangolin::Colour::Green().WithAlpha(0.6f));
       colours->Add(pangolin::Colour::Green().WithAlpha(0.9f));
-  }
-
-  // OpenGL 'view' of data. We might have many views of the same data.
-  pangolin::Plotter plotter(&log, std::move(colours), 0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
+      return pangolin::Plotter(&log, pangolin::ColourWheel(std::move(colours)), 0.0f,4.0f*(float)M_PI/tinc,-2.0f,2.0f,(float)M_PI/(4.0f*tinc),0.5f);
+    }
+  }();
   plotter.SetBounds(0.0, 1.0, 0.0, 1.0);
   plotter.Track("$i");
 

--- a/tools/Plotter/main.cpp
+++ b/tools/Plotter/main.cpp
@@ -95,7 +95,7 @@ int main( int argc, char* argv[] )
 
     pangolin::CreateWindowAndBind("Plotter", 640, 480);
 
-    pangolin::Plotter plotter(&log, std::make_unique<pangolin::ColourWheel>(0.6), xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
+    pangolin::Plotter plotter(&log, xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
     if( (bool)args["x"] || (bool)args["y"]) {
         plotter.ClearSeries();
         std::vector<std::string> xvec = pangolin::Split(xs,',');

--- a/tools/Plotter/main.cpp
+++ b/tools/Plotter/main.cpp
@@ -95,7 +95,7 @@ int main( int argc, char* argv[] )
 
     pangolin::CreateWindowAndBind("Plotter", 640, 480);
 
-    pangolin::Plotter plotter(&log, xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
+    pangolin::Plotter plotter(&log, std::make_unique<pangolin::ColourWheel>(0.6), xrange.min, xrange.max, yrange.min, yrange.max, 0.001, 0.001);
     if( (bool)args["x"] || (bool)args["y"]) {
         plotter.ClearSeries();
         std::vector<std::string> xvec = pangolin::Split(xs,',');


### PR DESCRIPTION
The plotter has a virtual destructor an may be subclassed by a user. The changes there might break some user code. This PR keeps ColourWheel in plotter and changes the implementation of ColourWheel that is now an adapter to ColourProvider.

MacOS build failure seems to be unrelated to this PR. It seems to happen on sevenlovegrove/Pangolin/master too https://github.com/stevenlovegrove/Pangolin/issues/323.